### PR TITLE
[Test-PR] Move index.md to / from /docs 

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,6 @@
+# Kubernetes Efficient Power Level Exporter (Kepler)
+
+Kepler (Kubernetes-based Efficient Power Level Exporter) is a Prometheus exporter. It uses eBPF to probe CPU performance counters and Linux kernel tracepoints. These data and stats from cgroup and sysfs are fed into ML models to estimate energy consumption by Pods.
+
+Check us out on GitHub ➡️ [Kepler](https://github.com/sustainable-computing-io/kepler).
+


### PR DESCRIPTION
The website is broken right now. Moving index.md to / from /docs fixed the issue on my fork. Testing it out here. 

Signed-off-by: Parul <parsingh@redhat.com>