### PR TITLE
Add `Project` section to navigation with links to talks & Contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,3 @@ pip install mkdocs
   - Kepler DaemonSet Customization
   - Model Server Customziation
 ```
-
-## Talks & Demos
-[Demos](./demos/) contains a full list of presentations, such as talks and demos, that are either about Kepler or that reference Kepler.

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,17 +1,3 @@
 # Talks & Demos
 
-## Kepler Demos
-- "Sustainability the Container Native Way", Huamin Chen (Red Hat) & Chen Wang (IBM), Open Source Summit NA 2022 [[slides]](https://github.com/sustainable-computing-io/kepler/blob/main/doc/OSS-NA22.pdf)
-
-- "Sustainability Research the Cloud Native Way", Chen Wang (IBM) & Huamin Chen (Red Hat), KubeCon NA 2022 [[slides]](./demos/../KubeConNA-2022_Sustainability-Research-the-Cloud-Native-Way.pdf)
-
-- "Sustainability in Computing: Energy Efficient Placements of Edge Workloads", Parul Singh & Kaiyi Liu (Red Hat), Kubernetes Edge Day NA 2022 [[slides]](./demos/Kubernetes-Edge-Day.pdf)
-
-- "Green(ing) CI/CD: A Sustainability Journey with GitOps", Niki Manoledaki (Weaveworks), GitOpsCon NA 2022 [[slides]](./demos/GitOpsCon22-Sustainability-Journey.pdf)
-
-## Kepler References
-- "Panel Discussion: Moving Towards Environmentally Sustainable Operations with Cloud Native Tools", Niki Manoledaki (Weaveworks), Chris Lavery (Weaveworks), Marlow Weston (Intel), William Caban (Red Hat) [[recording]](https://www.youtube.com/watch?v=2_Sx9ElD3o8)
-
-- "How to Get Involved in CNCF Environmental Sustainability TAG", Marlow Weston (Intel) & Huamin Chen (Red Hat), KubeCon NA 22 [[recording]](https://www.youtube.com/watch?v=XFZZ9YfOyI8)
-
-- "Smart Green Computing Cloud Native Operations", William Caban & Federico Rossi (Red Hat), KubeCon NA 2022 [[recording]](https://www.youtube.com/watch?v=cuzj-gUfYXA)
+A list of talks and demos about Kepler, or that reference Kepler, can be found in the documentation website [here](https://sustainable-computing.io/project/resources/).

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -1,0 +1,5 @@
+# Contributing
+
+We welcome all kinds of contributions to Kepler from the community!
+
+For an in-depth guide on how to get started, checkout the Contributing Guide [here](https://github.com/sustainable-computing-io/kepler/blob/main/CONTRIBUTING.md).

--- a/docs/project/resources.md
+++ b/docs/project/resources.md
@@ -1,0 +1,27 @@
+# Resources
+
+## Talks & Demos
+
+We really appreciate talks and demos about Kepler from the community. If you have made a presentation that demonstrated or referenced Kepler, please open a PR to add it to this page!
+
+### Kepler Demos
+
+The list below contains talks that demo Kepler, its capabilities, and how to gather energy metrics of various Kubernetes resources.
+
+- "Sustainability the Container Native Way", Huamin Chen (Red Hat) & Chen Wang (IBM), Open Source Summit NA 2022 [[slides]](https://github.com/sustainable-computing-io/kepler/blob/main/doc/OSS-NA22.pdf)
+
+- "Sustainability Research the Cloud Native Way", Chen Wang (IBM) & Huamin Chen (Red Hat), KubeCon NA 2022 [[slides]](https://github.com/sustainable-computing-io/kepler/blob/main/demos/KubeConNA-2022_Sustainability-Research-the-Cloud-Native-Way.pdf)
+
+- "Sustainability in Computing: Energy Efficient Placements of Edge Workloads", Parul Singh & Kaiyi Liu (Red Hat), Kubernetes Edge Day NA 2022 [[slides]](https://github.com/sustainable-computing-io/kepler/blob/main/demos/Kubernetes-Edge-Day.pdf)
+
+- "Green(ing) CI/CD: A Sustainability Journey with GitOps", Niki Manoledaki (Weaveworks), GitOpsCon NA 2022 [[slides]](https://github.com/sustainable-computing-io/kepler/blob/main/demos/GitOpsCon22-Sustainability-Journey.pdf)
+
+### Kepler References
+
+The list below contains talks that reference Kepler in discussions on energy efficiency and cloud-native environmental sustainability.
+
+- "Panel Discussion: Moving Towards Environmentally Sustainable Operations with Cloud Native Tools", Niki Manoledaki (Weaveworks), Chris Lavery (Weaveworks), Marlow Weston (Intel), William Caban (Red Hat) [[recording]](https://www.youtube.com/watch?v=2_Sx9ElD3o8)
+
+- "How to Get Involved in CNCF Environmental Sustainability TAG", Marlow Weston (Intel) & Huamin Chen (Red Hat), KubeCon NA 22 [[recording]](https://www.youtube.com/watch?v=XFZZ9YfOyI8)
+
+- "Smart Green Computing Cloud Native Operations", William Caban & Federico Rossi (Red Hat), KubeCon NA 2022 [[recording]](https://www.youtube.com/watch?v=cuzj-gUfYXA)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ nav:
       - 'usage/kepler_daemon.md'
       - 'usage/model_server.md'
       - 'usage/trouble_shooting.md'
+    - Project:
+      - 'project/resources.md'
 
 extra:
   version:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - 'usage/trouble_shooting.md'
     - Project:
       - 'project/resources.md'
+      - 'project/contributing.md'
 
 extra:
   version:


### PR DESCRIPTION
This PR adds a `Project` section to the navigation bar.

This new section currently contains a section with `Resources`, which contains a list of demos & talks. It also includes a `Contributing` section, with a link to the Contributing Guide.