### PR TITLE
Fix manifest output path

### DIFF
--- a/docs/installation/kepler.md
+++ b/docs/installation/kepler.md
@@ -68,13 +68,13 @@ TRAIN_DEPLOY|patch online-trainer sidecar to model server| MODEL_SERVER_DEPLOY o
     -  kubectl v1.21+
     -  make
     -  go
- -  manifest sources and outputs will be in  `_output/generated-manifests` by default
+ -  manifest sources and outputs will be in  `_output/generated-manifest` by default
 
 
 #### Deploy using Kubectl
 
 ```
-# kubectl apply -f _output/generated-manifests/deployment.yaml
+# kubectl apply -f _output/generated-manifest/deployment.yaml
 ```
 
 ## Deploy the Prometheus operator and the whole monitoring stack


### PR DESCRIPTION
There is a type in previous commit.

**before:**
```bash
> kubectl apply -f _output/generated-manifests/deployment.yaml
error: the path "_output/generated-manifests/deployment.yaml" does not exist
```

**after**
```bash
> kubectl apply -f _output/generated-manifest/deployment.yaml
namespace/kepler created
serviceaccount/kepler-sa created
role.rbac.authorization.k8s.io/prometheus-k8s created
clusterrole.rbac.authorization.k8s.io/kepler-clusterrole created
rolebinding.rbac.authorization.k8s.io/prometheus-k8s created
clusterrolebinding.rbac.authorization.k8s.io/kepler-clusterrole-binding created
configmap/kepler-cfm created
service/kepler-exporter created
daemonset.apps/kepler-exporter created
servicemonitor.monitoring.coreos.com/kepler-exporter created
```


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>