### PR TITLE
format and separate subclass of pipeline

### DIFF
--- a/docs/model_training/pipeline.md
+++ b/docs/model_training/pipeline.md
@@ -33,18 +33,48 @@ In the current implementation, there are two default active pipelines as shown b
 
 ![](../fig/current_pipeline.png)
 
-They use different isolators: *ProfileIsolator* and *MinIdleIsolator*. *ProfileIsolator* relies on profiled background powers (profiles) and removes resource usages by system processes from the training while *MinIdleIsolator* assumes minimum power as an idle power and includes resource usages by system processes in the training. The pipeline with *ProfileIsolator* will be applied first if the profile that matches the training `node_type` is available. Otherwise, the other pipeline will be applied. (check how profiles are generated [here](./model_profile.md))
+### Extractor
 
-*Trainers* implements `Trainer` class. The common process for each `node_type` is to 
-1. load previous checkpoint model via implemented `load_local_checkpoint` or `load_remote_checkpoint`. If the checkpoint cannot be loaded, initialize the model by calling implemented `init_model`.
+From Kepler queries, the default extractor generates a dataframe with the following columns.
+
+timestamp|features|labels[unit]\_[#unit]\_[component]\_power|node type
+---|---|---|---
+timestamp|e.g.,<br>cgroupfs_cpu_usage_us<br>cgroupfs_memory_usage_bytes<br>cgroupfs_system_cpu_usage_us<br>cgroupfs_user_cpu_usage_us|e.g.,<br>package_0_package_power<br>package_1_package_power<br>package_0_core_power<br>package_1_core_power<br>package_0_uncore_power<br>package_1_uncore_power<br>package_0_dram_power<br>package_1_dram_power|node_type
+
+### Isolator
+
+There are two available isolators: *ProfileIsolator* and *MinIdleIsolator*. 
+
+*ProfileIsolator* relies on profiled background powers (profiles) and removes resource usages by system processes from the training while *MinIdleIsolator* assumes minimum power as an idle power and includes resource usages by system processes in the training. 
+
+The pipeline with *ProfileIsolator* will be applied first if the profile that matches the training `node_type` is available. Otherwise, the other pipeline will be applied. 
+
+(check how profiles are generated [here](./model_profile.md))
+
+### Trainer
+
+*Trainers* implements `Trainer` class (with 9 abstract methods). The common process for each `node_type` is to 
+
+1. load previous checkpoint model via implemented `(i) load_local_checkpoint` or `(ii) load_remote_checkpoint`. If the checkpoint cannot be loaded, initialize the model by calling implemented `(iii) init_model`.
+
 2. load and apply scaler to input data
-3. call implemented `train` and save the checkpoint via `save_checkpoint`
-4. check whether to achive the model and push to database via `should_archive`. If yes, 
-   1. get triner-specific basic metdata via `get_basic_metadata`
-   2. fill with required metadata, save it as metadata file (metadata.json)
-   3. call `save_model`
-   4. If `get_weight_dict` function is implemented (only for linear regression based trainer), the weight dict will be saved in the file named `weight.json`.
-   5. archive the model folder. The model name will be in the format `<trainer class>_<node_type>`.
-   6. push the archived model and `weight.json` (if available) to the database
+
+3. call implemented `(iv) train` and save the checkpoint via `(v) save_checkpoint`
+
+4. check whether to achive the model and push to database via `(vi) should_archive`. If yes, 
+      
+      4.1.  get triner-specific basic metdata via `(vii) get_basic_metadata`
+
+      4.2. fill with required metadata, save it as metadata file (metadata.json)
+
+      4.3. call `(viii) save_model`
+
+      4.4. If `(iv) get_weight_dict` function is implemented (only for linear regression based trainer), the weight dict will be saved in the file named `weight.json`.
+
+      4.5. archive the model folder. The model name will be in the format `<trainer class>_<node_type>`.
+
+      4.6. push the archived model and `weight.json` (if available) to the database
+
+If the trainer is based on scikit-learn, consider implementing only `init_model` method of `ScikitTrainer`.
 
 The intermediate checkpoint and output of model will be saved locally in folder `MODEL_PATH/<PowerSource>/<ModelOutputType>/<FeatureGroup>`. The default `MODEL_PATH` is `src/models`.


### PR DESCRIPTION
This PR fixed wrong formatting of the previous PR https://github.com/sustainable-computing-io/kepler-doc/pull/39 and separated explanation for each subclass in pipeline.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>