### PR TITLE
fix(components): Fix typo in design > components

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -8,7 +8,7 @@ Monitor container power consumption with the [metrics](metrics.md) made availabl
 ![](https://raw.githubusercontent.com/sustainable-computing-io/kepler/main/doc/kepler-arch.png)
 
 ## Kepler Model Server
-The main feature of Kepler Model Server is to return a [power estimation model](./power_estimation.md) correponding to the request containing target granularity (node in total, node per each processor component, pod in total, pod per each processor component), available input metrics, model filters such as acccuracy.
+The main feature of Kepler Model Server is to return a [power estimation model](./power_estimation.md) corresponding to the request containing target granularity (node in total, node per each processor component, pod in total, pod per each processor component), available input metrics, model filters such as acccuracy.
 
 In addition, the online-trainer can be deployed as a sidecar container to the server (main container) to execute trainning pipelines and update the model on the fly when power metrics are available.
 


### PR DESCRIPTION
This is a super small change, but wanted to fix a typo in the components section. 

There was a typo in corresponding. This updates the verbiage to be correct.