### PR TITLE
translate architecture to Chinese and fix typo?

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -8,15 +8,15 @@ Monitor container power consumption with the [metrics](metrics.md) made availabl
 ![](https://raw.githubusercontent.com/sustainable-computing-io/kepler/main/doc/kepler-arch.png)
 
 ## Kepler Model Server
-The main feature of Kepler Model Server is to return a [power estimation model](./power_estimation.md) corresponding to the request containing target granularity (node in total, node per each processor component, pod in total, pod per each processor component), available input metrics, model filters such as acccuracy.
+The main feature of Kepler Model Server is to return a [power estimation model](./power_estimation.md) corresponding to the request containing target granularity (node in total, node per each processor component, pod in total, pod per each processor component), available input metrics, model filters such as accuracy.
 
 In addition, the online-trainer can be deployed as a sidecar container to the server (main container) to execute trainning pipelines and update the model on the fly when power metrics are available.
 
 Check us out on GitHub ➡️ [Kepler Model Server](https://github.com/sustainable-computing-io/kepler-model-server)
 
 ## Kepler Estimator Sidecar
-Kepler estimator is a client module to kepler model server running as a sidecar of Kepler exporter (main container).
+Kepler Estimator is a client module to kepler model server running as a sidecar of Kepler Exporter (main container).
 
-This python will serve a PowerReequest from model package in Kepler exporter as defined in estimator.go via unix domain socket `/tmp/estimator.sock`.
+This python will serve a PowerReequest from model package in Kepler Exporter as defined in estimator.go via unix domain socket `/tmp/estimator.sock`.
 
 Check us out on GitHub ➡️ [Kepler Estimator](https://github.com/sustainable-computing-io/kepler-estimator)

--- a/docs/design/architecture.zh.md
+++ b/docs/design/architecture.zh.md
@@ -1,0 +1,22 @@
+# 组件
+
+## Kepler Exporter
+Kepler Exporter公开了有关Kubernetes组件（如Pods和Nodes）能耗的各种指标。
+
+请点击链接查看相关能耗[指标/metrics](metrics.md)的定义。
+
+![](https://raw.githubusercontent.com/sustainable-computing-io/kepler/main/doc/kepler-arch.png)
+
+## Kepler Model Server
+Kepler Model Server主要提供[能耗预估模型](./power_estimation.md)，该模型支持对各种粒度的（如节点数，节点CPU数，Pod数，Pod进程数）的请求，并返回指标，精准性模型过滤器。
+
+另外，在online训练模式，Kepler Model Server可以作为边车部署。并且执行训练相关流程，实时更新模型。
+
+项目地址 ➡️ [Kepler Model Server](https://github.com/sustainable-computing-io/kepler-model-server)
+
+## Kepler Estimator Sidecar
+Kepler Estimator作为Kepler Exporter的边车部署，将会以客户端模式运行，访问kepler model server，请求模型。
+
+Kepler estimator与Kepler Exporter通过socket的方式（`/tmp/estimator.sock`）进行连接。相关的代码在Kepler Exporter的`estimator.go`文件中有定义和描述。
+
+项目地址 ➡️ [Kepler Estimator](https://github.com/sustainable-computing-io/kepler-estimator)


### PR DESCRIPTION
<img width="1034" alt="image" src="https://github.com/sustainable-computing-io/kepler-doc/assets/7820992/f824c8fa-ccc7-410d-8107-1f5c8a0d2cd4">
local preview. the page generation works.