### PR TITLE
Add description of environment variables for Redfish

### DIFF
--- a/docs/installation/kepler.md
+++ b/docs/installation/kepler.md
@@ -75,6 +75,13 @@ ESTIMATOR_SIDECAR_DEPLOY|patch estimator sidecar and corresponding configmap to 
 MODEL_SERVER_DEPLOY|deploy model server and corresponding configmap to kepler daemonset|-
 TRAIN_DEPLOY|patch online-trainer sidecar to model server| MODEL_SERVER_DEPLOY option set
 
+Following options are available for Redfish client, you can set them as environment variables of kepler-exporter. They affect all of Redfish access from Kepler Exporter.
+
+Option|Default value|Description
+---|---
+REDFISH_PROBE_INTERVAL_IN_SECONDS|60|Interval in seconds to get power consumption via Redfish.
+REDFISH_SKIP_SSL_VERIFY|true|`true` if TLS verification is disabled on connecting to Redfish endpoint.
+
 `build-manifest` requirements:
 -  kubectl v1.21+
 -  make

--- a/docs/installation/kepler.md
+++ b/docs/installation/kepler.md
@@ -78,7 +78,7 @@ TRAIN_DEPLOY|patch online-trainer sidecar to model server| MODEL_SERVER_DEPLOY o
 Following options are available for Redfish client, you can set them as environment variables of kepler-exporter. They affect all of Redfish access from Kepler Exporter.
 
 Option|Default value|Description
----|---
+---|---|---
 REDFISH_PROBE_INTERVAL_IN_SECONDS|60|Interval in seconds to get power consumption via Redfish.
 REDFISH_SKIP_SSL_VERIFY|true|`true` if TLS verification is disabled on connecting to Redfish endpoint.
 


### PR DESCRIPTION
As I mentioned in https://github.com/sustainable-computing-io/kepler-doc/pull/74#issuecomment-1639066588 , `REDFISH_PROBE_INTERVAL_IN_SECONDS` and `REDFISH_SKIP_SSL_VERIFY` have been added in https://github.com/sustainable-computing-io/kepler/pull/734 , but they have not documented yet. They are important stuff to configure Kepler and Redfish, so they should be documented.