### PR TITLE
docs: fix typos and rm unneeded sub-menu

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -23,7 +23,7 @@ All the metrics specific to the Kepler Exporter are prefixed with `kepler_`.
 
 - **kepler_container_core_joules_total** (Counter)
     This measures the total energy consumption on CPU cores that  a certain container has used.
-    Generally, when the system has access to `RAPL`_ metrics, this metric will reflect the porportinal container energy consumption of the RAPL
+    Generally, when the system has access to `RAPL`_ metrics, this metric will reflect the proportional container energy consumption of the RAPL
     Power Plan 0 (PP0), which is the energy consumed by all CPU cores in the socket.
     However, this metric is processor model specific and may not be available on some server CPUs.
     The RAPL CPU metric that is available on all processors that support RAPL is the package, which we will detail
@@ -143,7 +143,7 @@ Note:
 ## Kepler metrics for Node information:
 
 - **kepler_node_nodeInfo** (Counter)
-    This metric shows the node metada like the node CPU architecture.
+    This metric shows the node metadata like the node CPU architecture.
 
     Note that this metrics is deprecated and might be updated to `kepler_node_info` in the next release.
 

--- a/docs/design/power_estimation.md
+++ b/docs/design/power_estimation.md
@@ -8,7 +8,7 @@ There are two alternatives of estimators.
 
 - **General Estimator Sidecar**: This estimator transforms the usage metrics and applies with the trained models which can be any regression models from scikit-learn library or any neuron networks from Keras (TensorFlow). To use this estimator, the [Kepler General Estimator](./architecture/#kepler-estimator-sidecar) component needs to be enabled.
 
-On top of that, the trained models as well as weights can be updated periodically with online trainning routine by connecting the [Kepler Model Server]((./architecture/#kepler-model-server)) component.
+On top of that, the trained models as well as weights can be updated periodically with online training routine by connecting the [Kepler Model Server]((./architecture/#kepler-model-server)) component.
 
 
 ## Deployment Scenarios
@@ -30,7 +30,7 @@ This additional overhead must be tradeoff to an increasing estimation accuracy e
 
 **Minimum deployment connecting to Kepler Model Server**
 
-To get the updated weights which is expected to provide better estimation accuracy, Kepler may connect to remote Kepler Model Server that performs online trainning using data from the system with the power measuring tool as below.
+To get the updated weights which is expected to provide better estimation accuracy, Kepler may connect to remote Kepler Model Server that performs online training using data from the system with the power measuring tool as below.
 
 ![](../fig/disable_estimator_sidecar.png)
 

--- a/docs/hardwareengagement/index.md
+++ b/docs/hardwareengagement/index.md
@@ -6,11 +6,11 @@ You are able to take this out as a todo list and step by step to make kepler eng
 ## Stage 0 Proof
 In this Stage, we will focus on basic data can be collected by golang, and you can build your own kepler which running on your device well. The following steps can running in parallel.
 ### Binary build and container build.
-Currently kepler container image is from a GPU image to support GPU case. Considering a general case for IOT device. You may need to build kepler from UBI image. We recommand you following steps below to setup a local build env and try to build.
+Currently kepler container image is from a GPU image to support GPU case. Considering a general case for IOT device. You may need to build kepler from UBI image. We recommend you following steps below to setup a local build env and try to build.
 
 1. Find a linux OS.
 1. Install kepler dependencies as ebpf golang(BCC), linux header and build kepler(from main branch or latest release branch) binary.
-1. (Optional)Modify [dockerfile](https://github.com/sustainable-computing-io/kepler/tree/main/build) to build the contaienr image.
+1. (Optional)Modify [dockerfile](https://github.com/sustainable-computing-io/kepler/tree/main/build) to build the container image.
 
 ### Power consumption API.
 Currently, we use power consumption API as RAPL or ACPI. For some of the devices, you may need to find your own way to get power consumption, and implement in golang for kepler usage. For further plan, please ref [here](https://github.com/sustainable-computing-io/kepler/issues/644)
@@ -22,10 +22,10 @@ Currently, we relays on ebpf and cgroup to characterization a process/pod. Hence
 During this Stage, we are going to ref Kepler model. To integrate and implement your own logic specific to your device and deep dive into Power consumption API.
 
 ### Scope
-You should know the scope of the Power consumption API. How many API do you have? Is it categoried by CPU/memeory/IO or not?
+You should know the scope of the Power consumption API. How many API do you have? Is it categorized by CPU/memory/IO or not?
 
-### Internval
-You should know the internals of the Power consumption API. As kepler collect ebpf and cgroup data in each 3s by default, you should know the internal and make them in same time slot.
+### Interval
+You should know the intervals of the Power consumption API. As kepler collect ebpf and cgroup data in each 3s by default, you should know the interval and make them in same time slot.
 
 ### Verify
 You can cross check and verify the data.

--- a/docs/installation/kepler-helm.md
+++ b/docs/installation/kepler-helm.md
@@ -13,7 +13,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 helm repo add kepler https://sustainable-computing-io.github.io/kepler-helm-chart
 ```
 
-You can see the latest version by using the folllowing command:
+You can see the latest version by using the following command:
 
 ```bash
 helm search repo kepler
@@ -43,11 +43,11 @@ The following table lists the configurable parameters for this chart and their d
 
 Parameter|Description| Default
 ---|---|---
-global.namespace| Kubernete namespace for kepler |kepler
+global.namespace| Kubernetes namespace for kepler |kepler
 image.repository|Repository for Kepler Image| quay.io/sustainable\_computing\_io/kepler
 image.pullPolicy|Pull policy for Kepler|Always
 image.tag|Image tag for Kepler Image |latest
-serviceAccount.name|Service acccount name for Kepler|kepler-sa
+serviceAccount.name|Service account name for Kepler|kepler-sa
 service.type|Kepler service type|ClusterIP
 service.port|Kepler service exposed port|9102
 

--- a/docs/installation/kepler-operator.md
+++ b/docs/installation/kepler-operator.md
@@ -37,7 +37,7 @@ kubectl apply -k config/samples/
 
 ## Set up Grafana Dashboard
 
-Using `GRAFANA_ENABLE=true` configured the `kube-prometheus` monitoring stack in the namesapce `monitoring`.
+Using `GRAFANA_ENABLE=true` configured the `kube-prometheus` monitoring stack in the namespace `monitoring`.
 To access the Grafana Console locally on the browser port-forward on 3000 using the following command:
 
 ```sh

--- a/docs/installation/kepler.md
+++ b/docs/installation/kepler.md
@@ -71,8 +71,8 @@ OPENSHIFT_DEPLOY|patch openshift-specific attribute to kepler daemonset and depl
 PROMETHEUS_DEPLOY|patch prometheus-related resource (ServiceMonitor, RBAC role, rolebinding) |require prometheus deployment which can be OpenShift integrated or [custom deploy](#deploy-the-prometheus-operator)
 CLUSTER_PREREQ_DEPLOY|deploy prerequisites for kepler on openshift cluster| OPENSHIFT_DEPLOY option set
 CI_DEPLOY|update proc path for kind cluster using in CI|-
-ESTIMATOR_SIDECAR_DEPLOY|patch estimator sidecar and corresponding configmap to kepler daemonset|-
-MODEL_SERVER_DEPLOY|deploy model server and corresponding configmap to kepler daemonset|-
+ESTIMATOR_SIDECAR_DEPLOY|patch estimator sidecar and corresponding ConfigMap to kepler daemonset|-
+MODEL_SERVER_DEPLOY|deploy model server and corresponding ConfigMap to kepler daemonset|-
 TRAIN_DEPLOY|patch online-trainer sidecar to model server| MODEL_SERVER_DEPLOY option set
 
 Following options are available for Redfish client, you can set them as environment variables of kepler-exporter. They affect all of Redfish access from Kepler Exporter.

--- a/docs/installation/strategy.md
+++ b/docs/installation/strategy.md
@@ -1,6 +1,6 @@
 # Installation Strategies
 
-While you are free to explore any deployments but the recommended stratgies are :
+While you are free to explore any deployments but the recommended strategies are :
 
 | *OCP 4.13*      | *Microshift*     | *RHEL*  |  *ROSA* | *Kind* |
 | ------------- | -------------  | ----- | ----- | ----|

--- a/docs/model_training/kepler-model-server.md
+++ b/docs/model_training/kepler-model-server.md
@@ -4,7 +4,7 @@ Kepler model server is a supplementary project of Kepler that facilitates power 
 ![](../fig/model-server-components-simplified.png)
 
 
-**Pipeline Input:** Prometheus query results during the trainning workload war running.
+**Pipeline Input:** Prometheus query results during the training workload war running.
 
 **Pipeline Output:** A directory that contains archived absolute and dynamic power models trained by each available feature group which is labeled by each available energy source.
 
@@ -16,7 +16,7 @@ Kepler model server is a supplementary project of Kepler that facilitates power 
 - [**Energy/Power source**](./pipeline.md#power-source) a power meter source of power label.
 - [**Model type**](./pipeline.md#model-output-type) a type of model with or without background isolation.
 - [**Feature group**](./pipeline.md#feature-group) a utilization metric source of model input.
-- **Archived model** a folder and zip file in the format`[trainer name]_[node type]` where trainer is a name of training solution such as `GradientBoostingRegressor` and `node_type` is a catogorized [profile](./model_profile.md) of the server used for training. The folder contains 
+- **Archived model** a folder and zip file in the format`[trainer name]_[node type]` where trainer is a name of training solution such as `GradientBoostingRegressor` and `node_type` is a categorized [profile](./model_profile.md) of the server used for training. The folder contains 
     - metadata.json
     - model files
     - weight.json (model weight for local estimator supported models such as linear regression (LR))

--- a/docs/model_training/pipeline.md
+++ b/docs/model_training/pipeline.md
@@ -23,14 +23,14 @@ The features are groupped by the metric sources.
 
 Group Name|Features|Kepler Metric Source(s)
 ---|---|---
-CounterOnly|COUNTER_FEAUTRES|[Hardware Counter](../design/metrics.md#hardware-counter-metrics)
+CounterOnly|COUNTER_FEATURES|[Hardware Counter](../design/metrics.md#hardware-counter-metrics)
 CgroupOnly|CGROUP_FEATURES|[cGroups](../design/metrics.md#cgroups-metrics)
 BPFOnly|BPF_FEATURES|[BPF](../design/metrics.md#base-metric)
 KubeletOnly|KUBELET_FEATURES|[Kubelet](../design/metrics.md#kubelet-metrics)
 IRQOnly|IRQ_FEATURES|[IRQ](../design/metrics.md#irq-metrics)
-CounterIRQCombined|COUNTER_FEAUTRES, IRQ_FEATURES|BPF and Hardware Counter
-Basic|COUNTER_FEAUTRES, CGROUP_FEATURES, BPF_FEATURES, KUBELET_FEATURES|All except IRQ and node information
-WorkloadOnly|COUNTER_FEAUTRES, CGROUP_FEATURES, BPF_FEATURES, IRQ_FEATURES, KUBELET_FEATURES|All except node information
+CounterIRQCombined|COUNTER_FEATURES, IRQ_FEATURES|BPF and Hardware Counter
+Basic|COUNTER_FEATURES, CGROUP_FEATURES, BPF_FEATURES, KUBELET_FEATURES|All except IRQ and node information
+WorkloadOnly|COUNTER_FEATURES, CGROUP_FEATURES, BPF_FEATURES, IRQ_FEATURES, KUBELET_FEATURES|All except node information
 Full|WORKLOAD_FEATURES, SYSTEM_FEATURES|All
 
 > node information refers to value from [kepler_node_info](../design/metrics.md#kepler-metrics-for-node-information) metric.
@@ -71,9 +71,9 @@ The pipeline with *ProfileIsolator* will be applied first if the profile that ma
 
 3. call implemented `(iv) train` and save the checkpoint via `(v) save_checkpoint`
 
-4. check whether to achive the model and push to database via `(vi) should_archive`. If yes, 
+4. check whether to archive the model and push to database via `(vi) should_archive`. If yes, 
       
-      4.1.  get triner-specific basic metdata via `(vii) get_basic_metadata`
+      4.1.  get trainer-specific basic metadata via `(vii) get_basic_metadata`
 
       4.2. fill with required metadata, save it as metadata file (metadata.json)
 

--- a/docs/usage/general_config.md
+++ b/docs/usage/general_config.md
@@ -9,8 +9,8 @@ Kepler DaemonSet Deployment|daemon.exporter.port|Metric exporter port|9102|
 Kepler DaemonSet Deployment|daemon.estimator-sidecar.enabled|[Kepler Estimator Sidecar](./../design/architecture/#kepler-estimator-sidecar) patch|false|
 Kepler DaemonSet Deployment|daemon.estimator-sidecar.image|Kepler estimator sidecar image|quay.io/sustainable_computing_io/kepler-estimator:latest
 Kepler DaemonSet Deployment|daemon.estimator-sidecar.mnt-path|Mount path between main container and the sidecar for unix domain socket|/tmp
-Kepler DaemonSet Enviroment (METRIC_PATH)|daemon.exporter.path|Path to export metrics|/metrics
-Kepler DaemonSet Enviroment (MODEL_SERVER_ENABLE)|model-server.enaled|[Kepler Model Server Pod Pod](./../design/architecture/#kepler-model-server) connection|false
+Kepler DaemonSet Environment (METRIC_PATH)|daemon.exporter.path|Path to export metrics|/metrics
+Kepler DaemonSet Environment (MODEL_SERVER_ENABLE)|model-server.enaled|[Kepler Model Server Pod Pod](./../design/architecture/#kepler-model-server) connection|false
 *[*model-server.enaled*]*|
 Model Server Pod Pod Environment (MODEL_SERVER_PORT)|model-server.port|Model serving port of model server|8100 
 Model Server Pod Pod Environment (PROM_SERVER)|model-server.prom|Endpoint to Prometheus metric server |http://prometheus-k8s.monitoring.svc.cluster.local:9090
@@ -32,12 +32,12 @@ Kepler DaemonSet Environment (KUBELET_METRICS)|kubelet|List of performance metri
 Kepler DaemonSet Environment (GPU_METRICS)|gpu|List of performance metrics to enable from gpu source| * (enable all available metrics from gpu source)
 ***ExportMetric CR*** (single item: default)|||
 Kepler DaemonSet Environment (PERF_METRICS)|perf|List of performance metrics to export | * (enable all collected performance metrics)
-Kepler DaemonSet Environment (EXPORT_NODE_TOTAL_POWER)|node_total_power|Trigger whether to export node total power| true
-Kepler DaemonSet Environment (EXPORT_NODE_COMPONENT_POWERS)|node_component_powers|Trigger whether to export node powers by components| true
-Kepler DaemonSet Environment (EXPORT_POD_TOTAL_POWER)|pod_total_power|Trigger whether to export pod total power| true
-Kepler DaemonSet Environment (EXPORT_POD_COMPONENT_POWERS)|pod_component_powers|Trigger whether to export pod powers by components| true
+Kepler DaemonSet Environment (EXPORT_NODE_TOTAL_POWER)|node_total_power|Toggle whether to export node total power| true
+Kepler DaemonSet Environment (EXPORT_NODE_COMPONENT_POWERS)|node_component_powers|Toggle whether to export node powers by components| true
+Kepler DaemonSet Environment (EXPORT_POD_TOTAL_POWER)|pod_total_power|Toggle whether to export pod total power| true
+Kepler DaemonSet Environment (EXPORT_POD_COMPONENT_POWERS)|pod_component_powers|Toggle whether to export pod powers by components| true
 ***EstimatorConfig CR*** (multiple items: node-total-power, node-component-powers, pod-total-power, pod-component-powers)|||
-Kepler DaemonSet Environment (MODEL_CONFIG.[MODEL_ITEM]_ESTIMATOR)|use-sidecar|Triggle whether to use estimator sidecar for power estimation|false
+Kepler DaemonSet Environment (MODEL_CONFIG.[MODEL_ITEM]_ESTIMATOR)|use-sidecar|Toggle whether to use estimator sidecar for power estimation|false
 Kepler DaemonSet Environment (MODEL_CONFIG.[MODEL_ITEM]_MODEL)|fixed-model|Specify model name| (auto-selected)
 Kepler DaemonSet Environment (MODEL_CONFIG.[MODEL_ITEM]_FILTERS)|filters|Specify model filter conditions in string|  (auto-selected)
 Kepler DaemonSet Environment (MODEL_CONFIG.[MODEL_ITEM]_INIT_URL)|init-url|URL to initial model location| -
@@ -56,4 +56,4 @@ Kepler DaemonSet Environment (GPU_USAGE_METRIC)|core_metric|Specify metric for c
     For example,
     
     * *NODE_TOTAL_POWER*: archived model to estimate node total power used by estimator sidecar
-    * *POD_COMPONENTS_MODEL_WEIGHT*: model weight to estimate pod component powers used by linear regressor embbed in Kepler main component.
+    * *POD_COMPONENTS_MODEL_WEIGHT*: model weight to estimate pod component powers used by linear regressor embedded in Kepler main component.

--- a/docs/usage/kepler_daemon.md
+++ b/docs/usage/kepler_daemon.md
@@ -24,7 +24,7 @@ data:
     POD_COMPONENT_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip
 ```
 
-2. Mount the confimap to DeamonSet:
+2. Mount the ConfigMap to DaemonSet:
 ```yaml
   spec:
     containers:

--- a/docs/usage/model_server.md
+++ b/docs/usage/model_server.md
@@ -19,7 +19,7 @@ To set environments by ConfigMap,
           PROM_SSL_DISABLE: 'true'
           INITIAL_MODELS_LOC: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
 
-2. Mount the confimap to DeamonSet
+2. Mount the ConfigMap to DaemonSet
 
         spec:
           containers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,8 +39,7 @@ nav:
       - 'usage/model_server.md'
       - 'usage/trouble_shooting.md'
       - 'usage/deep_dive.md'
-    - Hardware Engagement:
-      - 'hardwareengagement/index.md'
+    - Hardware Engagement: 'hardwareengagement/index.md'
     - Model Training:
       - 'model_training/kepler-model-server.md'
       - 'model_training/pipeline.md'


### PR DESCRIPTION
Noticed a few typos so tried to address, also seemed that the Hardware Engagement page didn't really require to be a section as just requires an additional click from the user. 

- https://github.com/sustainable-computing-io/kepler-doc/blob/main/docs/design/metrics.md?plain=1#L68 This sentence generally doesn't read right to me with the mixed capitalisation on GPU etc, `processeses` definitely isn't correct, but not sure how to address.

I don't have mkdocs running locally, installing the requirements failed for me 🤷  so these changes would need to be verified (apologies)