### PR TITLE
Add Grafana design diagram reference

### DIFF
--- a/docs/installation/community-operator.md
+++ b/docs/installation/community-operator.md
@@ -146,6 +146,11 @@ Sign in to the Grafana dashboard using the credentials `kepler:kepler`.
 The dashboard can also be accessed through the OCP UI, Go to Networking ❯ Routes.
 ![](../fig/ocp_installation/operator_installation_ocp_7_0.6.z.png)
 
+## Grafana Deployment Overview
+
+Refer to the [Grafana Deployment Overview](https://github.com/sustainable-computing-io/kepler-operator/blob/v1alpha1/docs/developer/assets/grafana-deployment-overview.png)
+
+![](https://github.com/sustainable-computing-io/kepler-operator/blob/v1alpha1/docs/developer/assets/grafana-deployment-overview.png)
 
 ---
 


### PR DESCRIPTION
Updated community-operator.md file to include hyperlink to Grafana design diagram located in kepler-operator repository.