### PR TITLE
docs: update uninstall commands in Helm section

### DIFF
--- a/docs/installation/kepler-helm.md
+++ b/docs/installation/kepler-helm.md
@@ -55,5 +55,5 @@ service.port|Kepler service exposed port|9102
 To uninstall this chart, use the following steps
 
 ```bash
-helm delete --purge kepler --tiller-namespace <namespace>
+helm delete kepler --namespace kepler
 ```

--- a/docs/installation/kepler-helm.zh.md
+++ b/docs/installation/kepler-helm.zh.md
@@ -58,5 +58,5 @@ service.port|Kepler service exposed port|9102
 ## 卸载 Kepler
 您可以通过以下命令卸载
 ```bash
-helm delete --purge kepler --tiller-namespace <namespace>
+helm delete kepler --namespace kepler
 ```


### PR DESCRIPTION
Helm 3 deprecated the use of --purge flag since delete command auto-purges the packages unless --keep-history is specified Also replace <namespace> with default namespace as kepler since it will be the most common use case