### PR TITLE
Fix powercap sysfs false statement

### DIFF
--- a/docs/design/kepler-energy-sources.md
+++ b/docs/design/kepler-energy-sources.md
@@ -65,10 +65,10 @@ Kepler chooses to use one enenry sources in the following order of preference:
 
 ## Permissions required
 ### MSRs
-root access is required to use the msr driver
+Root access is required to use the msr driver
 
 ### Sysfs (powercap)
-Root access is not needed  to use powercap driver
+Root access is required to use powercap driver
 
 
 

--- a/docs/design/kepler-energy-sources.md
+++ b/docs/design/kepler-energy-sources.md
@@ -1,4 +1,4 @@
-# Kepler Enery Sources
+# Kepler Energy Sources
 
 ## Background
 

--- a/docs/kepler_model_server/api.md
+++ b/docs/kepler_model_server/api.md
@@ -42,7 +42,7 @@ Parameters of [TrainRequest](https://github.com/sustainable-computing-io/kepler-
 |key|value|description
 |---|---|---|
 |name|string|pipeline/model name
-|energy_source|valid key in [PowerSourceMap](https://github.com/sustainable-computing-io/kepler-model-server/tree/main/src/util/train_types.py)|target enery source to train for 
+|energy_source|valid key in [PowerSourceMap](https://github.com/sustainable-computing-io/kepler-model-server/tree/main/src/util/train_types.py)|target energy source to train for 
 |trainer|TrainAttribute|attributes for training
 |prome_response|json|prom response with workload for power model training
 


### PR DESCRIPTION
Hi, 

Because of the following CVE [1], Root privilege is actually required to read the powercap sysfs.

BR,
Anthony

[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/advisory-guidance/running-average-power-limit-energy-reporting.html#cve-2020-8694