### PR TITLE
explicitly install mkdocs

### DIFF
--- a/.github/workflows/mkdocs-ghpages.yaml
+++ b/.github/workflows/mkdocs-ghpages.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           +: |
             gomplate.ca^v3.11.4
+      - run: pip install mkdocs
       - run: pip install mkdocs-material mkdocs-static-i18n
       - run: gomplate -d adopters=./data/adopters.yaml -f templates/adopters.md -o docs/project/adopters.md
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
CI failed on missing `mkdocs`. This is to install the command explicitly.

https://github.com/sustainable-computing-io/kepler-doc/actions/runs/7451130030/job/20271529085