### PR TITLE
pin python to 3.12.0 to avoid ci errors

### DIFF
--- a/.github/workflows/mkdocs-ghpages.yaml
+++ b/.github/workflows/mkdocs-ghpages.yaml
@@ -6,10 +6,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '3.12.0'
       - uses: teaxyz/setup@v0
         with:
           +: |


### PR DESCRIPTION
latest CI error is caused by 3.12.1 python. Pin the python version to 3.12.0 to avoid errors