### PR TITLE
use python 3.11

### DIFF
--- a/.github/workflows/mkdocs-ghpages.yaml
+++ b/.github/workflows/mkdocs-ghpages.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12.0'
+          python-version: '3.11.0'
       - uses: teaxyz/setup@v0
         with:
           +: |


### PR DESCRIPTION
latest CI still broke on python 3.12, downgrading to 3.11