### PR TITLE
update model training - node profile page

### DIFF
--- a/docs/kepler_model_server/node_profile.md
+++ b/docs/kepler_model_server/node_profile.md
@@ -1,7 +1,5 @@
 # Node Profile
 
-To form a group of machines (nodes), the idea is to run a benchmark suite towards a bunch of machines, collect performance reported by the benchmarks, and apply clustering algorithm such as *kmeans*.
+We form a group of machines (nodes) called [node type](./pipeline.md#node-spec) based on processor model, the number of cores, the number of chips, memory size, and maximum CPU frequency. When collecting the data from the bare metal machine, these attributes are automatically extracted and kept as a machine spec in json format.
 
-For each group of [node type](./pipeline.md#node-spec), we make a profile composing of background power when the resource usage is almost constant without user workload, minimum, maximum power for each power components (e.g., core, uncore, dram, package, platform), and normalization scaler (i.e., MinMaxScaler), standardization scaler (i.e., StandardScaler) for each [feature group](./pipeline.md#available-metrics).
-
-Check the profiling tool [here](https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/src/profile).
+A power model will be built per node type. For each group of node type, we make a profile composing of background power when the resource usage is almost constant without user workload, minimum, maximum power for each power components (e.g., core, uncore, dram, package, platform), and normalization scaler (i.e., MinMaxScaler), standardization scaler (i.e., StandardScaler) for each [feature group](./pipeline.md#available-metrics).


### PR DESCRIPTION
According to the issue https://github.com/sustainable-computing-io/kepler-model-server/issues/235, this PR updates outdated information about node profile in kepler-model-server.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>