### PR TITLE
docs: fix metric name for other node joules total

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -178,7 +178,7 @@ All the metrics specific to the Kepler Exporter are prefixed with `kepler`.
 
     Similar to container metrics, but representing the aggregation of all containers running on the node and operating system (i.e. "system_process").
 
-- **kepler_node_other_host_components_joules_total** (Counter)
+- **kepler_node_other_joules_total** (Counter)
 
     Similar to container metrics, but representing the aggregation of all containers running on the node and operating system (i.e. "system_process").
 


### PR DESCRIPTION
* the metric with the name "kepler_node_other_host_components_joules_total" does not exist in the current exporter, but instead a metric named "kepler_node_other_joules_total" exists (which is not documented so far)
* assuming this metric was just renamed, this commit adapts the documentation accordingly