### PR TITLE
docs: added docker as requirement for kepler-operator

### DIFF
--- a/docs/installation/kepler-operator.md
+++ b/docs/installation/kepler-operator.md
@@ -4,6 +4,7 @@
 
 Before you start make sure you have:
 
+- `docker` installed and configured to run as non-root by default
 - `kubectl` installed
 - `kind` installed
 - Clone the `kepler-operator` [repository](https://github.com/sustainable-computing-io/kepler-operator)

--- a/docs/installation/strategy.md
+++ b/docs/installation/strategy.md
@@ -10,3 +10,4 @@ While you are free to explore any deployments but the recommended strategies are
 
 - Kernel 4.18+
 - `kubectl` v1.21.0+
+- `docker` installed non-root by default


### PR DESCRIPTION
During my installation of kepler from source and kepler-operator, I discovered that the builds do not work on Podman alone, and have altered the docs to specify this.