### PR TITLE
chore: migrate from requirements.txt to pyproject.toml

### DIFF
--- a/.github/workflows/mkdocs-ghpages.yaml
+++ b/.github/workflows/mkdocs-ghpages.yaml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11.0
+      - name: Install dependencies
+        run: pip install -e .
       - uses: pkgxdev/setup@v1
         with:
           +: gomplate.ca@3.11.4
-      - run: pip install mkdocs
-      - run: pip install mkdocs-material mkdocs-static-i18n
       - run: gomplate -d adopters=./data/adopters.yaml -f templates/adopters.md -o docs/project/adopters.md
-      - run: python -m mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ documentation.
 Make sure `Python 3.8` or greater is installed, then run:
 
 ```bash
-pip install -r requirements.txt
+# Recommended: Use hatch for integrated development environment
+hatch shell
+
+# Alternative: Install with pyproject.toml manually
+pip install -e .
+
+# Alternative with uv (faster, modern package manager)
+uv sync
+
 ```
 
 ## mkdocs Commands
@@ -56,7 +64,10 @@ GitHub codespaces [provides a generous free tier](https://github.com/features/co
     ```bash
     virtualenv .venv
     source .venv/bin/activate
-    pip install -r requirements.txt
+    # Recommended: Use hatch
+    hatch shell
+    # OR manual installation
+    pip install -e .
     ```
 
 1. Once built, type `mkdocs serve`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kepler-docs"
+description = "Documentation for Kepler (Kubernetes Efficient Power Level Exporter)"
+version = "0.4.0"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Kepler Contributors"}
+]
+maintainers = [
+    {name = "Kepler Contributors"}
+]
+keywords = ["kubernetes", "energy", "power", "sustainability", "documentation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Documentation",
+    "Topic :: System :: Monitoring",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocs-static-i18n>=1.2",
+]
+
+[dependency-groups]
+# Development tools (additional dependencies beyond the main ones)
+dev = [
+    # Development utilities could go here
+    # e.g., "pre-commit", "ruff", etc.
+]
+ci = [
+    # CI/CD specific tools could go here
+    # Currently handled by GitHub Actions with super-linter
+]
+
+[project.urls]
+Homepage = "https://sustainable-computing.io"
+Documentation = "https://sustainable-computing.io"
+Repository = "https://github.com/sustainable-computing-io/kepler"
+"Bug Tracker" = "https://github.com/sustainable-computing-io/kepler/issues"
+
+[tool.hatch.version]
+path = "mkdocs.yml"
+pattern = "version: (?P<version>[^\\s]+)"
+
+[tool.hatch.build.targets.wheel]
+packages = []
+
+[tool.hatch.envs.default]
+dependencies = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocs-static-i18n>=1.2",
+]
+
+[tool.hatch.envs.default.scripts]
+serve = "mkdocs serve"
+serve-remote = "mkdocs serve -a 0.0.0.0:8000"
+build = "mkdocs build"
+generate-adopters = "gomplate -d adopters=./data/adopters.yaml -f templates/adopters.md -o docs/project/adopters.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-mkdocs
-mkdocs-static-i18n
-mkdocs-material


### PR DESCRIPTION
- Remove requirements.txt in favor of pyproject.toml dependency management
- Update README.md to remove legacy requirements.txt installation methods
- Update GitHub workflow to use pip install -e . instead of individual packages
- Simplify workflow by using mkdocs command directly instead of python -m