### PR TITLE
chore: ensure only essentail files are included for wheel target

### DIFF
--- a/.github/workflows/mkdocs-ghpages.yaml
+++ b/.github/workflows/mkdocs-ghpages.yaml
@@ -2,6 +2,9 @@
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,4 +19,6 @@ jobs:
         with:
           +: gomplate.ca@3.11.4
       - run: gomplate -d adopters=./data/adopters.yaml -f templates/adopters.md -o docs/project/adopters.md
-      - run: mkdocs gh-deploy --force
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: mkdocs gh-deploy --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,16 @@ path = "mkdocs.yml"
 pattern = "version: (?P<version>[^\\s]+)"
 
 [tool.hatch.build.targets.wheel]
-packages = []
+# For a documentation project, include the essential files
+only-include = [
+    "docs/",
+    "templates/",
+    "data/",
+    "overrides/",
+    "mkdocs.yml",
+    "README.md",
+    "LICENSE"
+]
 
 [tool.hatch.envs.default]
 dependencies = [


### PR DESCRIPTION
This commit updates the `pyproject.toml` file to ensure that only essential files are included in the wheel package as its not a traditional python package.

This fixes error when running `pip install -e .`