### PR TITLE
docs: update the dashboard link for Kepler Operator

### DIFF
--- a/docs/kepler-operator/installation/openshift.md
+++ b/docs/kepler-operator/installation/openshift.md
@@ -310,7 +310,7 @@ For advanced visualization, you can import the Kepler Grafana dashboard:
 
 ```bash
 # Get the dashboard JSON
-curl -O https://raw.githubusercontent.com/sustainable-computing-io/kepler-operator/main/hack/dashboard/assets/kepler/dashboard.json
+curl -O https://raw.githubusercontent.com/sustainable-computing-io/kepler-operator/v1alpha1/hack/dashboard/assets/kepler/dashboard.json
 
 # Import into your Grafana instance
 ```


### PR DESCRIPTION
This commit updates the broken link for Grafana dashboard in the Kepler Operator documentation.