### PR TITLE
ci: remove unwanted precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,3 @@ repos:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"] # yamllint disable-line rule:quoted-strings
-
-  - repo: https://github.com/pecigonzalo/pre-commit-shfmt
-    rev: v2.2.0
-    hooks:
-      - id: shell-fmt-go
-        types: [file]
-        files: \.sh$
-        args:
-          - -w
-          - -l


### PR DESCRIPTION
This commit removes the precommit hooks that are not required for the doc repository.