### PR TITLE
docs(support): add CNCF Slack link

### DIFF
--- a/docs/project/support.md
+++ b/docs/project/support.md
@@ -2,6 +2,8 @@
 
 ## The best ways to seek support are
 
-1. Opening an [issue](https://github.com/sustainable-computing-io/kepler/issues) in Kepler.
+1. Opening an [issue](https://github.com/sustainable-computing-io/kepler/issues) in Kepler
 
 2. Starting a [discussion](https://github.com/sustainable-computing-io/kepler/discussions)
+
+3. Joining the [#kepler-project](https://cloud-native.slack.com/archives/C05QK3KN3HT) channel on CNCF Slack ([get an invite](https://communityinviter.com/apps/cloud-native/cncf))


### PR DESCRIPTION
Closes #164

Add the `#kepler-project` CNCF Slack channel and a community invite link to the support page.