### PR TITLE
docs: correct Helm values nesting and ServiceMonitor defaults

### DIFF
--- a/docs/kepler/installation/guide.md
+++ b/docs/kepler/installation/guide.md
@@ -75,7 +75,7 @@ daemonset:
 
 # Enable ServiceMonitor for Prometheus
 serviceMonitor:
-  enabled: false # disabled by default
+  enabled: true
   interval: 5s # default is 5s
 ```
 

--- a/docs/kepler/installation/guide.md
+++ b/docs/kepler/installation/guide.md
@@ -58,24 +58,25 @@ image:
   tag: "v0.10.0"
   pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 100m
-    memory: 400Mi
-  requests:
-    cpu: 100m
-    memory: 200Mi
+daemonset:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
 
-tolerations:
-  - operator: Exists
+  tolerations:
+    - operator: Exists
 
-nodeSelector:
-  kubernetes.io/os: linux
+  nodeSelector:
+    kubernetes.io/os: linux
 
 # Enable ServiceMonitor for Prometheus
 serviceMonitor:
-  enabled: true
-  interval: 30s
+  enabled: false # disabled by default
+  interval: 5s # default is 5s
 ```
 
 Install with custom values:
@@ -254,26 +255,26 @@ daemonset:
   securityContext:
     privileged: true
 
-# Resource limits
-resources:
-  limits:
-    cpu: 100m
-    memory: 400Mi
-  requests:
-    cpu: 100m
-    memory: 200Mi
+  # Resource limits
+  resources:
+    limits:
+      cpu: 100m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
 
-# Node scheduling
-tolerations:
-  - operator: Exists
+  # Node scheduling
+  tolerations:
+    - operator: Exists
 
-nodeSelector:
-  kubernetes.io/os: linux
+  nodeSelector:
+    kubernetes.io/os: linux
 
 # Monitoring
 serviceMonitor:
-  enabled: true
-  interval: 30s
+  enabled: false
+  interval: 5s
   scrapeTimeout: 10s
 ```
 

--- a/docs/kepler/installation/guide.zh.md
+++ b/docs/kepler/installation/guide.zh.md
@@ -61,24 +61,25 @@ image:
   tag: "v0.10.0"
   pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 100m
-    memory: 400Mi
-  requests:
-    cpu: 100m
-    memory: 200Mi
+daemonset:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
 
-tolerations:
-  - operator: Exists
+  tolerations:
+    - operator: Exists
 
-nodeSelector:
-  kubernetes.io/os: linux
+  nodeSelector:
+    kubernetes.io/os: linux
 
 # 为 Prometheus 启用 ServiceMonitor
 serviceMonitor:
   enabled: true
-  interval: 30s
+  interval: 5s # default is 5s
 ```
 
 使用自定义值安装：
@@ -257,26 +258,26 @@ daemonset:
   securityContext:
     privileged: true
 
-# 资源限制
-resources:
-  limits:
-    cpu: 100m
-    memory: 400Mi
-  requests:
-    cpu: 100m
-    memory: 200Mi
+  # 资源限制
+  resources:
+    limits:
+      cpu: 100m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
 
-# 节点调度
-tolerations:
-  - operator: Exists
+  # 节点调度
+  tolerations:
+    - operator: Exists
 
-nodeSelector:
-  kubernetes.io/os: linux
+  nodeSelector:
+    kubernetes.io/os: linux
 
 # 监控
 serviceMonitor:
-  enabled: true
-  interval: 30s
+  enabled: false
+  interval: 5s
   scrapeTimeout: 10s
 ```
 


### PR DESCRIPTION
### Summary 

- Nested resources, tolerations, and nodeSelector properties under the daemonset key to match the actual Kepler Helm templates.
- Synchronized default serviceMonitor enablement and interval values.