### PR TITLE
ci: upgrade pkgxdev setup to v4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
         run: pip install -e .
 
       - name: Install gomplate
-        uses: pkgxdev/setup@v1
+        uses: pkgxdev/setup@v4
         with:
           +: gomplate.ca@3.11.4
 


### PR DESCRIPTION
Current CI is hang on setup step. Increasing version might help.

ref: https://github.com/sustainable-computing-io/kepler-doc/actions/runs/29666569138/job/88567618039