### PR TITLE
docs: fix broken documentation link in installation guide

### DIFF
--- a/docs/kepler/installation/guide.md
+++ b/docs/kepler/installation/guide.md
@@ -311,7 +311,7 @@ helm upgrade kepler manifests/helm/kepler/ -n kepler \
 
 ### Getting Help
 
-- **Documentation**: <https://sustainable-computing.io/kepler/>
+- **Documentation**: <https://sustainable-computing.io/>
 - **Issues**: <https://github.com/sustainable-computing-io/kepler/issues>
 - **Discussions**: <https://github.com/sustainable-computing-io/kepler/discussions>
 - **Slack**: [#kepler channel in CNCF Slack](https://cloud-native.slack.com/archives/C06HYDN4A01)

--- a/docs/kepler/installation/guide.zh.md
+++ b/docs/kepler/installation/guide.zh.md
@@ -314,7 +314,7 @@ helm upgrade kepler manifests/helm/kepler/ -n kepler \
 
 ### 获取帮助
 
-- **文档**：<https://sustainable-computing.io/kepler/>
+- **文档**：<https://sustainable-computing.io/>
 - **问题**：<https://github.com/sustainable-computing-io/kepler/issues>
 - **讨论**：<https://github.com/sustainable-computing-io/kepler/discussions>
 - **Slack**：[CNCF Slack 中的 #kepler 频道](https://cloud-native.slack.com/archives/C06HYDN4A01)


### PR DESCRIPTION
## What

The **Getting Help** section of the installation guide links to `https://sustainable-computing.io/kepler/`, which returns a **404**. This PR points it to the site root `https://sustainable-computing.io/` (HTTP 200), the actual documentation landing page.

Applied to both language versions:
- `docs/kepler/installation/guide.md`
- `docs/kepler/installation/guide.zh.md`

## Verification

```
404 <- https://sustainable-computing.io/kepler/   (old)
200 <- https://sustainable-computing.io/          (new)
```