### PR TITLE
docs: add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - TBA
+reviewers:
+  - angelOlivares


### PR DESCRIPTION
Hi! This PR adds an OWNERS file to kepler-doc so we can follow the [Governance model from Kepler repo](https://github.com/sustainable-computing-io/kepler/blob/main/GOVERNANCE.md)

I'm adding myself (angelOlivares) as a reviewer and leaving approvers as TBA so that contributors in the community can opt in.